### PR TITLE
Update FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,7 @@
-# These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+ These are supported funding model platforms
+
+ github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username
@@ -10,3 +11,10 @@ liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
 custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+
+
+
+
+
+
+


### PR DESCRIPTION

These are supported funding model platforms
--
  |   |  
  |   | github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
  |   | patreon: # Replace with a single Patreon username
  |   | open_collective: # Replace with a single Open Collective username
  |   | ko_fi: # Replace with a single Ko-fi username
  |   | tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
  |   | community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
  |   | liberapay: # Replace with a single Liberapay username
  |   | issuehunt: # Replace with a single IssueHunt username
  |   | otechie: # Replace with a single Otechie username
  |   | custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

